### PR TITLE
Add ack tracking for PRs and Helps

### DIFF
--- a/plugins/ack.py
+++ b/plugins/ack.py
@@ -39,7 +39,11 @@ def process_message(data):
             outputs.append([channel, text, message_attrs])
             return
         halps = helps.Helps(config['redis'])
-        halps.ack(ack_channel)
+        count = halps.ack_help(ack_channel, username)
         text = ":angel: %s has acknowledged help for %s!" % (username,
                                                              ack_channel)
+
+        if count is not None and count > 0.0:
+            text = text +  " %s has acknowledged %d requests for help since tracking began." % (username, count)
+
         outputs.append([channel, text, message_attrs])

--- a/plugins/prack.py
+++ b/plugins/prack.py
@@ -28,7 +28,10 @@ def process_message(data):
             return
 
         prs = helps.Helps(config['redis'])
-        prs.ack(ack_pr)
+        count = prs.ack_pr(ack_pr, username)
         text = ":angel: %s has acknowledged PR review for %s!" % (username,
                                                                   ack_pr)
+        if count is not None and count > 0.0:
+            text = text +  " %s has acknowledged %d PRs since tracking began." % (username, count)
+
         outputs.append([channel, text, message_attrs])


### PR DESCRIPTION
- Add two more redis keys, one for PR acks and one for Help acks
- Change ack method to return score of the user instead of True
- Prevent gaming the system by only giving user a point when there was an outstanding request
- If user score is above 0, print it with the acknowledgement message

My bigger question is -- does production redis persist? :)
